### PR TITLE
Write a package in two passes, which lets me remove support for "pending" ints.

### DIFF
--- a/go/webpack/cbor/cbor.go
+++ b/go/webpack/cbor/cbor.go
@@ -8,8 +8,9 @@
 //     * 2 & 3: Byte and UTF-8 strings, with minimal encoding for lengths.
 //     * 4 & 5: Arrays and maps, with the number of elements known at the start
 //              of the container, encoded minimally.
-//  * Unsigned integers whose value isn't known when they're first inserted.
+//  * Pre-encoded items, by copying from a Reader.
 //  * Retrieval of the current byte offset within an array or map.
+//  * Items that don't fit in memory.
 //
 // Unsupported:
 //  * Negative integers (major type 1) between -2^63-1 and -2^64 inclusive,

--- a/go/webpack/cbor/cbor_writer_test.go
+++ b/go/webpack/cbor/cbor_writer_test.go
@@ -32,6 +32,7 @@ func newBufferCbor() *bufferCbor {
 	result.TopLevel = cbor.New(&result.Buffer)
 	return result
 }
+
 func (c *bufferCbor) Finish() []byte {
 	c.TopLevel.Finish()
 	return c.Buffer.Bytes()

--- a/go/webpack/cbor_format_test.go
+++ b/go/webpack/cbor_format_test.go
@@ -43,7 +43,8 @@ func TestWriteCbor(t *testing.T) {
 		},
 	}
 
-	cborPack, err := WriteCbor(&pack)
+	var cborPack bytes.Buffer
+	err := WriteCbor(&pack, &cborPack)
 	assert.NoError(t, err)
 
 	assert.Equal(t, bytes.Join([][]byte{
@@ -78,8 +79,8 @@ func TestWriteCbor(t *testing.T) {
 		[]byte{}, cbor.Encoded(cbor.TypeBytes, 30),
 		[]byte{}, []byte("I am example.com's index.html\n"),
 		// length.
-		cbor.EncodedFixedLen(8, cbor.TypePosInt, len(cborPack)),
+		cbor.EncodedFixedLen(8, cbor.TypePosInt, len(cborPack.Bytes())),
 		// magic2.
 		cbor.Encoded(cbor.TypeBytes, 8), []byte("🌐📦"),
-	}, []byte{}), cborPack)
+	}, []byte{}), cborPack.Bytes())
 }

--- a/go/webpack/cmd/wpktext2cbor/main.go
+++ b/go/webpack/cmd/wpktext2cbor/main.go
@@ -42,16 +42,8 @@ func main() {
 		Error.Fatal(err)
 	}
 
-	cbor, err := webpack.WriteCbor(&pack)
+	err = webpack.WriteCbor(&pack, out)
 	if err != nil {
 		Error.Fatal(err)
-	}
-
-	n, err := out.Write(cbor)
-	if err != nil {
-		Error.Fatal(err)
-	}
-	if n != len(cbor) {
-		Error.Fatal("Failed to write the whole package.")
 	}
 }


### PR DESCRIPTION
It also removes the O(#parts^2) slowdown from inserting offsets one at a time, and makes it possible to build packages larger than fit in memory.

@mrdewitt